### PR TITLE
Add multi-user support

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -1,0 +1,23 @@
+{
+   "client_id": "your-client-id",
+   "client_secret": "your-client-secret",
+   "token": "your-secret-token",
+   "refresh_token": "your-refresh-token",
+   "scopes": [
+       "user-read-recently-played",
+       "user-read-playback-state",
+       "playlist-read-private",
+       "playlist-read-collaborative",
+       "playlist-modify-private",
+       "playlist-modify-public",
+       "user-library-read",
+       "user-library-modify",
+       "user-read-private"
+   ],
+   "redirect_uri": "http://localhost:8988/callback",
+   "user": "your-user-name",
+   "discoverability": 5,
+   "playlist_size": 5,
+   "min_popularity": 50,
+   "playlist_name": "infinify"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -21,18 +21,18 @@
         <div class="nav-wrapper light-green">
             <a href="#" class="brand-logo center">Infinify</a>
             <ul id="nav-mobile" class="right">
-                <a id='login' class='hidden btn '>Login </a>
-
+                <a id='login' class='btn not-logged'>Login </a>
                 <a href='#' id='logged' class='hidden'>Welcome <b id='user-name'></b></a>
+                <a id='logout' class='hidden btn logged'>Logout </a>
 
             </ul>
         </div>
     </nav>
 
-    <div class="container">
+    <div class="container logged">
         <div class="row">
 
-            <div class="col s12 center-align logged">
+            <div class="col s12 center-align ">
 
                 <a class="" id='start-radio'>
                     <img src='css/images/play.png' </img>


### PR DESCRIPTION
Add multi-user support, store all private info in json objects in nodejs , even spotify clients (doesn't support multi user).

Use uuid auth header token to identify users (generated in nodejs at login time) 

Plus extra usability improvements: 
* logout button,
*  reload same page after login instead of opening "_blank"
* Footer 
* etc.

Manually tested.

![image](https://user-images.githubusercontent.com/1983672/31608259-fef49f70-b26f-11e7-8366-9aeb8b047134.png)

